### PR TITLE
fix: Build output directory structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./tsconfig.compile.json",
-    "watch": "tsc -watch -p ./tsconfig.compile.json",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
     "test": "jest test/*.test.ts",
     "lint": "eslint src test"
   },

--- a/tsconfig.compile.json
+++ b/tsconfig.compile.json
@@ -1,6 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"rootDirs": ["src"]
-	}
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,14 +3,15 @@
 		"module": "Node16",
 		"target": "ES2022",
 		"outDir": "out",
+		"rootDir": "src",
 		"lib": [
 			"ES2022"
 		],
 		"sourceMap": true,
-		"rootDirs": ["src", "test"],
 		"strict": true,
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,
 		"noUnusedParameters": true
-	}
+	},
+	"exclude": ["test/*"]
 }


### PR DESCRIPTION
The extension is now compiled to the root of the `out` directory.

Before this PR the `out` directory contained `src` and `test` subdirectories. The `extension.ts` was compiled to `out/src/extension.js`, which was not compatible with `main` definition in the `package.json`. 

## Changes

Excluded tests from `tsconfig.json`. Now there is no need for a separate `tsconfig.compile.json`.