### PR TITLE
refactor: Simplify staged files query

### DIFF
--- a/src/GitFacade.ts
+++ b/src/GitFacade.ts
@@ -28,14 +28,14 @@ export class GitFacade {
     async getMainBranch(): Promise<BranchName> {
         const CANDIDATES = ['main', 'master']
         for (const candidate of CANDIDATES) {
-            if (await this.doesBranchExist(candidate)) {
+            if (await this.hasBranch(candidate)) {
                 return candidate
             }
         }
         throw new Error('No main branch')
     }
 
-    async doesBranchExist(name: BranchName): Promise<boolean> {
+    private async hasBranch(name: BranchName): Promise<boolean> {
         const result = await this.git.raw(['branch', '-l', name])
         return (result.trim() !== '') 
     }

--- a/src/GitFacade.ts
+++ b/src/GitFacade.ts
@@ -15,9 +15,9 @@ export class GitFacade {
         this.git.cwd(path)
     }
 
-    async getStagedFiles(): Promise<string[]> {
+    async hasStagedFiles(): Promise<boolean> {
         const diff = await this.git.diff(['--name-only', '--cached']);
-        return diff.split('\n').filter((line) => line !== '')
+        return (diff.trim() !== '')
     }
 
     async getCurrentBranch(): Promise<BranchName> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,8 +21,8 @@ export const activate = (context: vscode.ExtensionContext): void => {
             }
             git.updateWorkingDirectory(workspaceFolder)
 
-            const stagedFiles = await git.getStagedFiles()
-            if (stagedFiles.length === 0) {
+            const hasStagedFiles = await git.hasStagedFiles()
+            if (!hasStagedFiles) {
                 vscode.window.showErrorMessage('No staged files')
                 return
             }

--- a/test/GitFacade.test.ts
+++ b/test/GitFacade.test.ts
@@ -67,4 +67,12 @@ describe('GitFacade', () => {
         expect(commits.map((c) => c.hash.length)).toEqual([expectedLength, expectedLength, expectedLength])
         expect(commits.map((c) => c.subject)).toEqual(['subject 3', 'subject 2', 'subject 1'])
     })
+
+    it('hasStagedFiles()', async () => {
+        expect(await facade.hasStagedFiles()).toBe(false)
+        await modifyFileAndStageChanges('foobar')
+        expect(await facade.hasStagedFiles()).toBe(true)
+        await git.commit('-')
+        expect(await facade.hasStagedFiles()).toBe(false)
+    })
 })


### PR DESCRIPTION
Refactored `getStagedFiles()` to `hasStagedFiles()`. The extension needs only query whether there are staged files or not.

## Other changes

Also renamed `doesBranchExist()` and changed the method visibility to private.
