### PR TITLE
refactor: Simplify `getLatestFixedCommit()`

### DIFF
--- a/src/GitFacade.ts
+++ b/src/GitFacade.ts
@@ -60,7 +60,7 @@ export class GitFacade {
     }
 
     async getLatestFixedCommit(): Promise<Commit> {
-        return (await this.queryCommits('--grep-reflog=rebase \(fixup\)', '--walk-reflogs', '-1'))[0]
+        return (await this.queryCommits('--grep-reflog=rebase (fixup)', '--walk-reflogs', '-1'))[0]
     }
 
     private async queryCommits(...args: string[]): Promise<Commit[]> {

--- a/src/GitFacade.ts
+++ b/src/GitFacade.ts
@@ -60,7 +60,7 @@ export class GitFacade {
     }
 
     async getLatestFixedCommit(): Promise<Commit> {
-        return (await this.queryCommits('-g', '-1', '--grep-reflog=rebase \(fixup\)'))[0]
+        return (await this.queryCommits('--grep-reflog=rebase \(fixup\)', '--walk-reflogs', '-1'))[0]
     }
 
     private async queryCommits(...args: string[]): Promise<Commit[]> {


### PR DESCRIPTION
Removed escaping of parenthesis characters. Note that this didn't escape the argument value as there was just a single backslash (it just escaped the character in the TypeScript source code). Escaping the argument value is not needed as git uses [basic](https://www.regular-expressions.info/posix.html) regex [by default](https://git-scm.com/docs/git-grep#Documentation/git-grep.txt---basic-regexp).

Also using longer argument name and reordered arguments to improve readability.
