### PR TITLE
feat: Support Git v2.25 and earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -25,3 +24,22 @@ jobs:
         run: npm run test
       - name: Run packaging smoke test
         run: npx @vscode/vsce package
+
+  old-version-support:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Git 2.25.1
+        run: |
+          echo "deb http://archive.ubuntu.com/ubuntu focal-updates main universe" | sudo tee /etc/apt/sources.list.d/focal.list
+          sudo apt-get update
+          sudo apt-get install --allow-downgrades -y git=1:2.25.1-1ubuntu3.13 git-man=1:2.25.1-1ubuntu3.13
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run unit tests
+        run: npm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Support Git v2.25 and earlier
+
 ## 1.2.0 (2025-01-19)
 
 - Highlight commits that match staged files

--- a/src/GitFacade.ts
+++ b/src/GitFacade.ts
@@ -64,7 +64,8 @@ export class GitFacade {
     }
 
     async getLatestFixedCommit(): Promise<Commit> {
-        return (await this.queryCommits('--grep-reflog=rebase (fixup)', '--walk-reflogs', '-1'))[0]
+        // old Git versions (earlier than v2.26) include "-i" in the message
+        return (await this.queryCommits('--grep-reflog=rebase (fixup)', '--grep-reflog=rebase -i (fixup)', '--walk-reflogs', '-1'))[0]
     }
 
     private async queryCommits(...args: string[]): Promise<Commit[]> {

--- a/test/GitFacade.test.ts
+++ b/test/GitFacade.test.ts
@@ -9,6 +9,7 @@ describe('GitFacade', () => {
     let facade: GitFacade
     let git: SimpleGit
     let repoDirectory: string
+    let mainBranch: string
 
     const configureGit = async () => {
         const configs = {
@@ -34,25 +35,26 @@ describe('GitFacade', () => {
     beforeEach(async () => {
         repoDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'temp-repo-'))
         git = simpleGit(repoDirectory)
-        await git.init(['-b', 'main'])
+        await git.init()
         await configureGit()
         await createCommit('lorem\n\n', 'subject 1')
         await createCommit('lorem\n\n\n\nipsum\n\n', 'subject 2')
         await createCommit('lorem\n\n\n\nipsum\n\n\n\ndolor', 'subject 3\n\nbody test')
         facade = new GitFacade()
         facade.updateWorkingDirectory(repoDirectory)
+        mainBranch = await facade.getMainBranch()
     })
 
     it('happy path', async () => {
         const FIXABLE_COMMIT_INDEX = 1
-        const commitsBefore = await facade.getMainBranchCommits('main')
+        const commitsBefore = await facade.getMainBranchCommits(mainBranch)
         const fixableCommit = commitsBefore[FIXABLE_COMMIT_INDEX]
         await modifyFileAndStageChanges('lorem\n\n\n\nfoobar\n\n')
         await facade.commitFixup(fixableCommit.hash)
         const isMergeConflict = await facade.rebaseFixupCommit(fixableCommit.hash)
         expect(isMergeConflict).toBe(false)
         const fixedCommit = await facade.getLatestFixedCommit()
-        const commitsAfter = await facade.getMainBranchCommits('main')
+        const commitsAfter = await facade.getMainBranchCommits(mainBranch)
         expect(commitsAfter[FIXABLE_COMMIT_INDEX].hash).toEqual(fixedCommit.hash)
         const fixedCommitDiff = await git.raw(['diff', '-U0', `${fixedCommit.hash}~`, `${fixedCommit.hash}`])
         expect(fixedCommitDiff).toContain('+\n+\n+foobar\n+\n')
@@ -61,7 +63,7 @@ describe('GitFacade', () => {
     })
 
     it('getMainBranchCommits()', async () => {
-        const commits = await facade.getMainBranchCommits('main')
+        const commits = await facade.getMainBranchCommits(mainBranch)
         expect(commits).toHaveLength(3)
         const expectedLength = (await git.raw(['rev-parse', '--short', 'HEAD'])).trim().length
         expect(commits.map((c) => c.hash.length)).toEqual([expectedLength, expectedLength, expectedLength])
@@ -69,11 +71,11 @@ describe('GitFacade', () => {
     })
 
     it('getFeatureBranchCommits()', async () => {
-        const branchName = `feature-${Date.now()}`
-        await git.checkoutLocalBranch(branchName)
-        expect(await facade.getFeatureBranchCommits(branchName, 'main')).toHaveLength(0)
+        const featureBranch = `feature-${Date.now()}`
+        await git.checkoutLocalBranch(featureBranch)
+        expect(await facade.getFeatureBranchCommits(featureBranch, mainBranch)).toHaveLength(0)
         await createCommit('foo', 'bar')
-        expect(await facade.getFeatureBranchCommits(branchName, 'main')).toHaveLength(1)
+        expect(await facade.getFeatureBranchCommits(featureBranch, mainBranch)).toHaveLength(1)
     })
 
     it('getStagedFiles()', async () => {


### PR DESCRIPTION
The rebase functionality was refactored in [Git v2.26](https://github.com/git/git/blob/master/Documentation/RelNotes/2.26.0.txt). Therefore the reflog messages were slightly different before that version.

Modified `getLatestFixedCommit()` to have alternative regexp so that the reflog entries are also found correctly in Git v2.25 and earlier.